### PR TITLE
(GH-44) Fix retrieving of files modified in the pull request

### DIFF
--- a/src/Cake.Issues.PullRequests.Tfs/Cake.Issues.PullRequests.Tfs.csproj
+++ b/src/Cake.Issues.PullRequests.Tfs/Cake.Issues.PullRequests.Tfs.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Cake.Issues" Version="0.6.0" />
     <PackageReference Include="Cake.Issues.PullRequests" Version="0.6.0" />
     <PackageReference Include="Cake.Tfs">
-      <Version>0.2.0</Version>
+      <Version>0.2.1</Version>
     </PackageReference>
     <PackageReference Include="Costura.Fody">
       <Version>3.1.0</Version>

--- a/src/Cake.Issues.PullRequests.Tfs/Capabilities/TfsFilteringByModifiedFilesCapability.cs
+++ b/src/Cake.Issues.PullRequests.Tfs/Capabilities/TfsFilteringByModifiedFilesCapability.cs
@@ -41,14 +41,14 @@
             var baseVersionDescriptor = new GitBaseVersionDescriptor
             {
                 VersionType = GitVersionType.Commit,
-                Version = this.PullRequestSystem.TfsPullRequest.LastSourceCommitId
+                Version = this.PullRequestSystem.TfsPullRequest.LastTargetCommitId
             };
 
             using (var gitClient = this.PullRequestSystem.CreateGitClient())
             {
                 var commitDiffs = gitClient.GetCommitDiffsAsync(
                     this.PullRequestSystem.TfsPullRequest.ProjectName,
-                    this.PullRequestSystem.TfsPullRequest.RepositoryName,
+                    this.PullRequestSystem.TfsPullRequest.RepositoryId,
                     true, // bool? diffCommonCommit
                     null, // int? top
                     null, // int? skip
@@ -57,14 +57,14 @@
                     null, // object userState
                     CancellationToken.None).Result;
 
+                this.Log.Verbose(
+                    "Found {0} changed file(s) in the pull request",
+                    commitDiffs.Changes.Count());
+
                 if (!commitDiffs.ChangeCounts.Any())
                 {
                     return new List<FilePath>();
                 }
-
-                this.Log.Verbose(
-                    "Found {0} changed file(s) in the pull request",
-                    commitDiffs.Changes.Count());
 
                 return
                     from change in commitDiffs.Changes


### PR DESCRIPTION
Fix retrieving of files modified in the pull request

Bumps dependency on Cake.Tfs to 0.2.1

Fixes #44 