### PR TITLE
(GH-50) Add alias which uses environment variables from Build

### DIFF
--- a/src/Cake.Issues.PullRequests.Tfs.Tests/TfsPullRequestSystemSettingsTests.cs
+++ b/src/Cake.Issues.PullRequests.Tfs.Tests/TfsPullRequestSystemSettingsTests.cs
@@ -57,6 +57,26 @@
                 // Then
                 result.IsArgumentNullException("repositoryUrl");
             }
+
+            [Fact]
+            public void Should_Throw_If_Credentials_For_PullRequestId_Are_Null()
+            {
+                // Given / When
+                var result = Record.Exception(() => new TfsPullRequestSystemSettings(new Uri("http://example.com"), 42, null));
+
+                // Then
+                result.IsArgumentNullException("credentials");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Credentials_For_SourceBranch_Are_Null()
+            {
+                // Given / When
+                var result = Record.Exception(() => new TfsPullRequestSystemSettings(new Uri("http://example.com"), "feature/foo", null));
+
+                // Then
+                result.IsArgumentNullException("credentials");
+            }
         }
     }
 }

--- a/src/Cake.Issues.PullRequests.Tfs/Cake.Issues.PullRequests.Tfs.csproj
+++ b/src/Cake.Issues.PullRequests.Tfs/Cake.Issues.PullRequests.Tfs.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Cake.Issues" Version="0.6.0" />
     <PackageReference Include="Cake.Issues.PullRequests" Version="0.6.0" />
     <PackageReference Include="Cake.Tfs">
-      <Version>0.2.1</Version>
+      <Version>0.2.2</Version>
     </PackageReference>
     <PackageReference Include="Costura.Fody">
       <Version>3.1.0</Version>

--- a/src/Cake.Issues.PullRequests.Tfs/TfsPullRequestSystemAliases.PullRequestSystem.cs
+++ b/src/Cake.Issues.PullRequests.Tfs/TfsPullRequestSystemAliases.PullRequestSystem.cs
@@ -101,6 +101,69 @@
 
         /// <summary>
         /// Gets an object for writing issues to Team Foundation Server or Azure DevOps pull request
+        /// where all required data is taken from the environment variables set by the Azure Pipelines / TFS build.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="credentials">Credentials to use to authenticate against Team Foundation Server or
+        /// Azure DevOps.</param>
+        /// <returns>Object for writing issues to Team Foundation Server or Azure DevOps pull request.</returns>
+        /// <example>
+        /// <para>Report code analysis issues reported as MsBuild warnings to a TFS pull request:</para>
+        /// <code>
+        /// <![CDATA[
+        ///     ReportIssuesToPullRequest(
+        ///         MsBuildCodeAnalysis(
+        ///             @"c:\build\msbuild.log",
+        ///             MsBuildXmlFileLoggerFormat),
+        ///         TfsPullRequests(
+        ///             TfsAuthenticationNtlm()),
+        ///         @"c:\repo");
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory(PullRequestsAliasConstants.PullRequestSystemCakeAliasCategory)]
+        public static IPullRequestSystem TfsPullRequests(
+            this ICakeContext context,
+            ITfsCredentials credentials)
+        {
+            context.NotNull(nameof(context));
+            credentials.NotNull(nameof(credentials));
+
+            return context.TfsPullRequests(new TfsPullRequestSystemSettings(credentials));
+        }
+
+        /// <summary>
+        /// Gets an object for writing issues to Team Foundation Server or Azure DevOps pull request
+        /// where all required data (including authentication token) is taken from the environment variables set by the Azure Pipelines / TFS build.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <returns>Object for writing issues to Team Foundation Server or Azure DevOps pull request.</returns>
+        /// <example>
+        /// <para>Report code analysis issues reported as MsBuild warnings to a TFS pull request:</para>
+        /// <code>
+        /// <![CDATA[
+        ///     ReportIssuesToPullRequest(
+        ///         MsBuildCodeAnalysis(
+        ///             @"c:\build\msbuild.log",
+        ///             MsBuildXmlFileLoggerFormat),
+        ///         TfsPullRequests(),
+        ///         @"c:\repo");
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory(PullRequestsAliasConstants.PullRequestSystemCakeAliasCategory)]
+        public static IPullRequestSystem TfsPullRequests(
+            this ICakeContext context)
+        {
+            context.NotNull(nameof(context));
+
+            return context.TfsPullRequests(new TfsPullRequestSystemSettings());
+        }
+
+        /// <summary>
+        /// Gets an object for writing issues to Team Foundation Server or Visual Studio Team Services pull request
         /// using the specified settings.
         /// </summary>
         /// <param name="context">The context.</param>

--- a/src/Cake.Issues.PullRequests.Tfs/TfsPullRequestSystemSettings.cs
+++ b/src/Cake.Issues.PullRequests.Tfs/TfsPullRequestSystemSettings.cs
@@ -50,6 +50,27 @@
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="TfsPullRequestSystemSettings"/> class
+        /// based on the environment variables set by the Azure Pipelines / TFS build.
+        /// </summary>
+        /// <param name="credentials">Credentials to use to authenticate against Team Foundation Server or
+        /// Azure DevOps.</param>
+        public TfsPullRequestSystemSettings(ITfsCredentials credentials)
+            : base(credentials)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TfsPullRequestSystemSettings"/> class
+        /// based on the environment variables set by the Azure Pipelines / TFS build
+        /// using the build authentication token.
+        /// </summary>
+        public TfsPullRequestSystemSettings()
+            : base(UsingTfsBuildOAuthToken())
+        {
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether pull request system should check if commit Id
         /// is still up to date before posting comments.
         /// Default value is <c>true</c>.


### PR DESCRIPTION
@pascalberger I would appreciate your review.

A couple of questions:

- As far as I can see, the number of unit tests is quite small. On the other hand, the base class `TfsPullRequestSettings` is covered pretty good. Do you think more unit tests should be added? Most of those will be almost identical copy&paste clones...

- I've renamed the VSTS to Azure DevOps in a separate commit, otherwise, the doc comments of the new stuff added become inconsistent. Is it ok? If not, please let me know and I'll revert that.

Fixes #50.