### PR TITLE
Consume the functionality to retrieve modified files from Cake.Tfs

### DIFF
--- a/src/Cake.Issues.PullRequests.Tfs/Cake.Issues.PullRequests.Tfs.csproj
+++ b/src/Cake.Issues.PullRequests.Tfs/Cake.Issues.PullRequests.Tfs.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Cake.Issues" Version="0.6.0" />
     <PackageReference Include="Cake.Issues.PullRequests" Version="0.6.0" />
     <PackageReference Include="Cake.Tfs">
-      <Version>0.2.2</Version>
+      <Version>0.2.4</Version>
     </PackageReference>
     <PackageReference Include="Costura.Fody">
       <Version>3.1.0</Version>


### PR DESCRIPTION
This change relies on the functionality to retrieve modified files added to `Cake.Tfs` version *0.2.4*. 

Partially addresses #22. 