### PR TITLE
(GH-107) Fix null reference exception if change contains no path

### DIFF
--- a/src/Cake.Issues.PullRequests.Tfs/TfsPullRequestSystem.cs
+++ b/src/Cake.Issues.PullRequests.Tfs/TfsPullRequestSystem.cs
@@ -276,7 +276,7 @@
             changes.NotNull(nameof(changes));
             path.NotNull(nameof(path));
 
-            var change = changes.Where(x => x.ItemPath.FullPath == "/" + path.ToString()).ToList();
+            var change = changes.Where(x => x.ItemPath != null && x.ItemPath.FullPath == "/" + path.ToString()).ToList();
 
             if (change.Count == 0)
             {


### PR DESCRIPTION
Fix null reference exception if change contains no path, which can be the case for deleted files