### PR TITLE
(GH-116) Build against Cake.Tfs 0.3.1-beta1

### DIFF
--- a/src/Cake.Issues.PullRequests.Tfs/Cake.Issues.PullRequests.Tfs.csproj
+++ b/src/Cake.Issues.PullRequests.Tfs/Cake.Issues.PullRequests.Tfs.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Cake.Issues" Version="0.7.0" />
     <PackageReference Include="Cake.Issues.PullRequests" Version="0.7.0" />
     <PackageReference Include="Cake.Tfs">
-      <Version>0.3.0</Version>
+      <Version>0.3.1-beta0001</Version>
     </PackageReference>
     <PackageReference Include="Costura.Fody">
       <Version>3.3.3</Version>


### PR DESCRIPTION
Build against Cake.Tfs 0.3.1-beta1 in preparation for targetting .NET Standard 2.0. Will update to Cake.Tfs 0.3.1 RTM once it is released and before release of Cake.Issues.PullRequests.Tfs.

Fixes #116 